### PR TITLE
Remove keras2onnx and refresh to newer version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "onnxmltools" %}
-{% set version = "1.8.0" %}
+{% set version = "1.9.1" %}
 
 
 package:
@@ -24,8 +24,6 @@ requirements:
     - python
     - numpy {{ numpy }}
     - onnx {{ onnx }}
-    - onnxconverter-common {{ onnxconverter_common }}
-    - protobuf {{ protobuf }}
     - skl2onnx
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/onnx/onnxmltools/archive/{{ version }}.tar.gz
-  sha256: 3f460b79d22a7fb1c9098ccacfe5da9da1558db4e96346bc847fde73c6cad6c0
+  sha256: 4900514a017bbe87577c4caaefc0b5ad58d2ee96cd2f2b4233c96ac424135521
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - python
   run:
     - python
-    - keras2onnx
     - numpy {{ numpy }}
     - onnx {{ onnx }}
     - onnxconverter-common {{ onnxconverter_common }}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

As keras2onnx is out of active development, it has been removed from the onnx-env.yaml. Hence updated the version of onnxmltools which doesn't not depend on keras2onnx.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
